### PR TITLE
Modify links so that they fill boxes

### DIFF
--- a/index.css
+++ b/index.css
@@ -46,6 +46,7 @@ body {
   font-size: 16px;
   vertical-align: top;
   box-sizing: border-box;
+  position: relative;
 }
 
 .gf-block--inner--spacer {
@@ -63,6 +64,15 @@ body {
 
 .gf-block--inner--keyword {
   display: inline-block;
+}
+
+.gf-block--inner--span {
+  position:absolute; 
+  width:100%;
+  height:100%;
+  top:0;
+  left: 0;
+  z-index: 1;
 }
 
 @media (max-width: 996px) {

--- a/index.js
+++ b/index.js
@@ -26,6 +26,9 @@ blockKeywordsProto.className = "gf-block--inner--keywords"
 var blockKeywordProto = document.createElement("div")
 blockKeywordProto.className = "gf-block--inner--keyword"
 
+var spanProto = document.createElement("span")
+spanProto.className = "gf-block--inner--span"
+
 // Global functions
 function squareify() {
   var blocks = document.querySelectorAll(".gf-block.square")
@@ -70,6 +73,7 @@ requirejs(["gridfolio"], function() {
         if (block.link) {
           link.href = block.link
           link.appendChild(blockTitle)
+          link.appendChild(spanProto.cloneNode())
           blockTitle = link
         }
 


### PR DESCRIPTION
Hi Christine

Thanks for making this, I think it's really elegant and simple to use and creates really nice portfolios.

So I made a portfolio the other day, and I pointed my grandma to it. The only relevance that has is that she's old and doesn't get tech, and she had trouble using my page because she was clicking on the keywords and the images, but they weren't doing anything.

I feel that the fact that just the heading text itself is a link instead of the entire box is a bit of a usability issue. This pull request fixes that to make the entire box act as a link, following instructions I found here: https://stackoverflow.com/a/3494108
